### PR TITLE
Correct typo in README.rst and README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The `graphql_server` package provides these public helper functions:
 
  * `run_http_query`
  * `encode_execution_results`
- * `laod_json_body`
+ * `load_json_body`
  * `json_encode`
  * `json_encode_pretty`
 

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ The ``graphql_server`` package provides these public helper functions:
 
 -  ``run_http_query``
 -  ``encode_execution_results``
--  ``laod_json_body``
+-  ``load_json_body``
 -  ``json_encode``
 -  ``json_encode_pretty``
 


### PR DESCRIPTION
Changed `laod_json_body` to `load_json_body` in README files.